### PR TITLE
Update SpellDatabase.cs

### DIFF
--- a/Evade/Database/SpellDatabase.cs
+++ b/Evade/Database/SpellDatabase.cs
@@ -6476,7 +6476,7 @@ namespace Evade
                new SpellData
                {
                    ChampionName = "Viego",
-                   SpellName = "ViegorR",
+                   SpellName = "ViegoR",
                    Slot = SpellSlot.R,
                    Type = SkillShotType.SkillshotCircle,
                    Delay = 600,


### PR DESCRIPTION
Fixed Viego R not being detected on cast.
Note : The Viego R Object Name is most likely going to detect Viego's ult from your own team (It's only an issue in normal/one for all games)